### PR TITLE
added null check to fix wrong .merge which is causing was causing bug…

### DIFF
--- a/src/middleware/native/oas-params.js
+++ b/src/middleware/native/oas-params.js
@@ -20,7 +20,8 @@ export class OASParams extends OASBase {
                 const contentType = Object.keys(oasRequest.requestBody.content)[0];
                 body = schema.parseBody(body, oasRequest.requestBody.content[contentType].schema);
             }
-            Object.values(params).forEach((param) => paramsObj[param.name] = _getParameterValue(req, param));
+            //added null check to fix wrong .merge which is causing was causing bug TypeError: Cannot convert undefined or null to object
+            Object.values(params).forEach(param => param.name && (paramsObj[param.name] = _getParameterValue(req, param)));
             res.defaultSend = res.send; // save original send for error handling
             res.locals.oas = { params: paramsObj, body: body };
             if(req.file || req.files && req.files.length > 0) res.locals.oas.files = [req.files, req.file].flat().filter((file) => file !== undefined);


### PR DESCRIPTION
… TypeError: Cannot convert undefined or null to object

added null check to fix wrong .merge which is causing was causing bug TypeError: Cannot convert undefined or null to object TypeError: Cannot convert undefined or null to object 2023-01-13 23:01:89 [oas-tools] ERROR: TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at _getParameterValue (file:///Users/acoder/Documents/GitHub/login-service/node_modules/@oas-tools/core/src/middleware/native/oas-params.js:93:36)
    at file:///Users/acoder/Documents/GitHub/login-service/node_modules/@oas-tools/core/src/middleware/native/oas-params.js:27:78

### Initial checks

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linked an issue to this pull request? (Create one if it does not exist)
* [ ] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [ISSUE TYPE] <!-- Bug or Suggestion -->

#### Description
<!-- Provide a brief description of the issue here -->

#### Implementation details
<!-- Details on the implementation performed (include code, images or whatever you consider necessary) -->

